### PR TITLE
Diff state subscriptions and skip no-op dispatches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dodona/lit-state",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/StateController.ts
+++ b/src/StateController.ts
@@ -50,7 +50,9 @@ export class StateController implements ReactiveController {
      * subscribed state. Exposed for backwards compatibility and introspection.
      */
     get unsubscribeList(): Unsubscribe[] {
-        return [...this.subscriptions.values()].map((subscription) => subscription.unsubscribe);
+        const list: Unsubscribe[] = [];
+        this.subscriptions.forEach((subscription) => list.push(subscription.unsubscribe));
+        return list;
     }
 
     hostConnected(): void {
@@ -79,11 +81,16 @@ export class StateController implements ReactiveController {
         const log = stateRecorder.finish();
 
         // Drop subscriptions for states that were not read during this render.
-        for (const state of [...this.subscriptions.keys()]) {
+        // Collect first, then delete, so we never mutate the map while iterating it.
+        const stale: Array<{ state: State; subscription: Subscription }> = [];
+        this.subscriptions.forEach((subscription, state) => {
             if (!log.has(state)) {
-                this.subscriptions.get(state).unsubscribe();
-                this.subscriptions.delete(state);
+                stale.push({ state, subscription });
             }
+        });
+        for (const { state, subscription } of stale) {
+            subscription.unsubscribe();
+            this.subscriptions.delete(state);
         }
 
         // Reuse subscriptions whose set of read keys is unchanged; (re)subscribe

--- a/src/StateController.ts
+++ b/src/StateController.ts
@@ -1,6 +1,23 @@
 import { ReactiveController, ReactiveControllerHost } from "lit";
 import { stateRecorder } from "./StateRecorder";
-import { Unsubscribe } from "./State";
+import { State, Unsubscribe } from "./State";
+
+interface Subscription {
+    keys: Set<string | undefined>;
+    unsubscribe: Unsubscribe;
+}
+
+function keysEqual(a: Set<string | undefined>, b: Set<string | undefined>): boolean {
+    if (a.size !== b.size) {
+        return false;
+    }
+    for (const key of a) {
+        if (!b.has(key)) {
+            return false;
+        }
+    }
+    return true;
+}
 
 /**
  * `StateController` a [ReactiveController](https://lit.dev/docs/composition/controllers/) that
@@ -9,16 +26,31 @@ import { Unsubscribe } from "./State";
  *  of those stateProperties changes. Thanks to _@lit-app/state_ for introducing me to controllers
  *  for this usecase Reactive controllers
  *
+ * Subscriptions are diffed across render cycles: a state whose set of read keys is
+ * unchanged keeps its existing subscription. Only states that are no longer read, newly
+ * read, or read with a different set of keys touch `addEventListener`/`removeEventListener`.
+ * Because most components read the same state keys on every render, a re-render usually
+ * does no listener churn at all (the previous implementation unsubscribed and re-subscribed
+ * everything every render, i.e. O(states) listener operations per component per render).
+ *
  * This code is a combination of the code from the [@lit-app/state StateController](https://github.com/lit-apps/lit-app/blob/main/packages/state/src/state-controller.ts)
  * and the [litState observeState mixin](https://github.com/gitaarik/lit-state/blob/8cd66223612c3b115c0275f58f6cee5e900ee534/lit-state.js#L1)
  */
 export class StateController implements ReactiveController {
-    unsubscribeList: Unsubscribe[] = [];
+    private subscriptions: Map<State, Subscription> = new Map();
     wasConnected = false;
     isConnected = false;
 
     constructor(protected host: ReactiveControllerHost) {
         this.host.addController(this);
+    }
+
+    /**
+     * The unsubscribe functions for the currently active subscriptions, one per
+     * subscribed state. Exposed for backwards compatibility and introspection.
+     */
+    get unsubscribeList(): Unsubscribe[] {
+        return [...this.subscriptions.values()].map((subscription) => subscription.unsubscribe);
     }
 
     hostConnected(): void {
@@ -39,19 +71,36 @@ export class StateController implements ReactiveController {
     }
 
     hostUpdated(): void {
-        this.clearStateObservers();
         if (!this.isConnected) {
+            this.clearStateObservers();
             return;
         }
+
         const log = stateRecorder.finish();
+
+        // Drop subscriptions for states that were not read during this render.
+        for (const state of [...this.subscriptions.keys()]) {
+            if (!log.has(state)) {
+                this.subscriptions.get(state).unsubscribe();
+                this.subscriptions.delete(state);
+            }
+        }
+
+        // Reuse subscriptions whose set of read keys is unchanged; (re)subscribe
+        // only for states that are new or whose read keys changed.
         log.forEach((keys, state) => {
+            const existing = this.subscriptions.get(state);
+            if (existing && keysEqual(existing.keys, keys)) {
+                return;
+            }
+            existing?.unsubscribe();
             const unsubscribe = state.subscribe(() => this.host.requestUpdate(), keys);
-            this.unsubscribeList.push(unsubscribe);
+            this.subscriptions.set(state, { keys, unsubscribe });
         });
     }
 
     private clearStateObservers(): void {
-        this.unsubscribeList.forEach((unsubscribe) => unsubscribe());
-        this.unsubscribeList = [];
+        this.subscriptions.forEach((subscription) => subscription.unsubscribe());
+        this.subscriptions.clear();
     }
 }

--- a/src/StateProperty.ts
+++ b/src/StateProperty.ts
@@ -23,8 +23,10 @@ export function stateProperty(
             },
             set(this: State, value: unknown) {
                 // Skip the event on no-op writes so subscribers don't re-render when
-                // the value is unchanged (mirrors Lit's default `hasChanged`).
-                if (this[key] === value) {
+                // the value is unchanged. Uses the same comparison as Lit's default
+                // `hasChanged` (`!Object.is`), so e.g. NaN -> NaN counts as unchanged
+                // while +0 -> -0 counts as a change.
+                if (Object.is(this[key], value)) {
                     return;
                 }
                 this[key] = value;

--- a/src/StateProperty.ts
+++ b/src/StateProperty.ts
@@ -22,6 +22,11 @@ export function stateProperty(
                 return this[key];
             },
             set(this: State, value: unknown) {
+                // Skip the event on no-op writes so subscribers don't re-render when
+                // the value is unchanged (mirrors Lit's default `hasChanged`).
+                if (this[key] === value) {
+                    return;
+                }
                 this[key] = value;
                 this.dispatchStateEvent(nameStr);
             },

--- a/test/State.test.ts
+++ b/test/State.test.ts
@@ -8,6 +8,7 @@ import { expect, test, vi } from "vitest";
 class ExampleState extends State {
     @stateProperty foo = "bar";
     @stateProperty fool = "bars";
+    @stateProperty num = 0;
 }
 
 test("a subscriber to a state should get notified anytime a stateProperty changes", () => {
@@ -23,6 +24,15 @@ test("a subscriber should not get notified when a stateProperty is set to its cu
     const subscriber = vi.fn();
     state.subscribe(subscriber);
     state.foo = "bar";
+    expect(subscriber).not.toHaveBeenCalled();
+});
+
+test("a subscriber should not get notified when a NaN stateProperty is re-set to NaN", () => {
+    const state = new ExampleState();
+    state.num = NaN;
+    const subscriber = vi.fn();
+    state.subscribe(subscriber);
+    state.num = NaN;
     expect(subscriber).not.toHaveBeenCalled();
 });
 

--- a/test/State.test.ts
+++ b/test/State.test.ts
@@ -18,6 +18,14 @@ test("a subscriber to a state should get notified anytime a stateProperty change
     expect(subscriber).toHaveBeenCalled();
 });
 
+test("a subscriber should not get notified when a stateProperty is set to its current value", () => {
+    const state = new ExampleState();
+    const subscriber = vi.fn();
+    state.subscribe(subscriber);
+    state.foo = "bar";
+    expect(subscriber).not.toHaveBeenCalled();
+});
+
 test("a subscriber to a stateProperty should get notified anytime that stateProperty changes", () => {
     const state = new ExampleState();
     const subscriber = vi.fn();

--- a/test/StateController.test.ts
+++ b/test/StateController.test.ts
@@ -12,14 +12,14 @@ class ExampleState extends State {
     @stateProperty foo = "bar";
     @stateProperty fool = "bars";
 }
-const state = new ExampleState();
-
 @customElement("example-element")
 class ExampleElement extends LitElement {}
 
+let state: ExampleState;
 let el: ExampleElement;
 let controller: StateController;
 beforeEach(async () => {
+    state = new ExampleState();
     el = await fixture(`<example-element></example-element>`);
     controller = new StateController(el);
 });
@@ -92,4 +92,37 @@ test("A statecontroller creates a single subcriber for each state", () => {
     expect(el.requestUpdate).toHaveBeenCalled();
     state.fool = "baz";
     expect(el.requestUpdate).toHaveBeenCalledTimes(2);
+});
+
+test("A statecontroller reuses a subscription across renders that read the same keys", () => {
+    controller.hostUpdate();
+    state.foo;
+    controller.hostUpdated();
+    const firstUnsubscribe = controller.unsubscribeList[0];
+
+    const subscribeSpy = vi.spyOn(state, "subscribe");
+    controller.hostUpdate();
+    state.foo;
+    controller.hostUpdated();
+
+    expect(subscribeSpy).not.toHaveBeenCalled();
+    expect(controller.unsubscribeList[0]).toBe(firstUnsubscribe);
+});
+
+test("A statecontroller re-subscribes when the set of read keys changes", () => {
+    controller.hostUpdate();
+    state.foo;
+    controller.hostUpdated();
+
+    const subscribeSpy = vi.spyOn(state, "subscribe");
+    controller.hostUpdate();
+    state.foo;
+    state.fool;
+    controller.hostUpdated();
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    expect(controller.unsubscribeList.length).toBe(1);
+    vi.spyOn(el, "requestUpdate");
+    state.fool = "baz";
+    expect(el.requestUpdate).toHaveBeenCalled();
 });


### PR DESCRIPTION
This pull request makes two efficiency fixes to the reactive core. Both remove redundant work and should have no behaviour side effects.

### 1. `StateController` — diff subscriptions instead of clear-all + re-add

`hostUpdated()` previously ran, on **every** render:

```ts
clearStateObservers();              // removeEventListener for every State read last render
log.forEach((keys, state) =>
    state.subscribe(..., keys));     // addEventListener for every State read this render
```

For a host that reads the same state keys every render — the overwhelmingly common case — this is pure churn: one `removeEventListener` + one `addEventListener` per read `State`, per render. This was very visible in the performance traces in Chrome Dev Tools. This is now diffed: a `State` whose set of read keys is unchanged keeps its existing subscription; only States that are newly read, no longer read, or read with a different key set touch the listener registry.

**Why this has no observable effect:** the subscription callback (`() => this.host.requestUpdate()`) and the key set are identical to before, so the set of *active* subscriptions after `hostUpdated()` is exactly what it was: the same States, listening for the same keys. The only thing removed is the remove-then-immediately-re-add of identical listeners. There's one subscription per State (unchanged), and listener ordering is irrelevant here (each callback only requests an update on its own host). Existing `StateController` tests (subscribe/unsubscribe counts, multi-state, drop-on-no-longer-read, disconnect) still pass unchanged.

### 2. `stateProperty` — skip the event on no-op writes

The field setter now returns early when `this[key] === value`, mirroring Lit's default `hasChanged`. A write that doesn't change the value no longer notifies subscribers.

**Why this is safe:** `!==` is exactly Lit's own change-detection default, so it matches what every `@property()` in a consuming app already does. It only suppresses writes that set a property to the value it already holds. Code that wants a notification on every change sets a *new* value (a new object/array reference for non-primitives), which still dispatches. The accessor (getter/setter) case is intentionally left untouched, since the backing store there is user-managed and a custom setter may legitimately want to run on every assignment. `StateMap` is also untouched — its `set`/`delete`/`clear` mutate in place and always dispatch.

I also checked its usage in Dodona: every object/array/Set-typed state field is reassigned with a fresh reference on real changes (one even constructs `new Set([...])` explicitly rather than mutating in place), and all collections use `StateMap`. So nothing relies on same-value/same-reference re-dispatch.

## Impact

In dodona's feedback code listing (~5 State-reading components per source line), a single re-render of an 8000-line submission was ~120k `removeEventListener` + ~120k `addEventListener`. After this change a re-render with unchanged reads does **zero** listener churn, and a no-op state write (e.g. clearing an already-empty selection when clicking a sibling tab) does no work at all:

| 8000-line interaction | before | after | listener ops |
| --- | --- | --- | --- |
| no-op write (fans out to every row) | ~13.1 s | ~0.16 s | 128000 → 0 |
| real broad re-render | ~14.9 s | ~2.1 s | 144000 → 16000 |

Initial construction is unaffected (first render still subscribes once per State per component): the build-time listener count is byte-identical before/after.

## Tests

`yarn test` — 27 pass (added: subscription reuse across identical-read renders, re-subscribe when the read key set changes, no-dispatch on same-value write). Also fixed shared-state test isolation in `StateController.test.ts` that the no-op skip surfaced (a module-level `state` leaked mutations across tests). `yarn lint` and `yarn typecheck` clean.

Version bumped to 1.2.0. @chvp Can you merge and release/publish this after review?