### PR TITLE
Publish releases from a tag and keep actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,26 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: monthly
+      time: "13:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 98
+    labels:
+      - "dependencies"
+    groups:
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "13:00"
+      timezone: Europe/Brussels
+    open-pull-requests-limit: 98
+    labels:
+      - "dependencies"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - no-release-notes
+  categories:
+    - title: "🚀 New Features"
+      labels:
+        - feature
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+    - title: "🧰 Maintenance"
+      labels:
+        - chore
+    - title: "✨ Changes"
+      labels:
+        - "*"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,89 @@
+name: Publish on NPM
+
+on:
+  push:
+    tags: ['v*']
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      dist_tag: ${{ steps.check.outputs.dist_tag }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
+    env:
+      TAG_NAME: ${{ github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Verify tag
+        id: check
+        run: |
+          VERSION="${TAG_NAME#v}"
+          if [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            DIST_TAG=latest
+            PRERELEASE=false
+          elif [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*$ ]]; then
+            DIST_TAG=next
+            PRERELEASE=true
+          else
+            echo "::error::$VERSION is not a semver version"
+            exit 1
+          fi
+          PKG=$(jq -r .version package.json)
+          if [ "$VERSION" != "$PKG" ]; then
+            echo "::error::Tag $TAG_NAME does not match package.json version $PKG"
+            exit 1
+          fi
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+  publish:
+    needs: [test, verify]
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      DIST_TAG: ${{ needs.verify.outputs.dist_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: yarn
+          # No registry-url: auth uses npm trusted publishing (OIDC), which
+          # needs no .npmrc, and the registry defaults to registry.npmjs.org.
+      - name: Install and Build
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+      - name: Publish @dodona/lit-state to NPM
+        run: npm publish --provenance --access public --tag "$DIST_TAG"
+  release:
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PRERELEASE: ${{ needs.verify.outputs.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag --prerelease
+          else
+            gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag
+          fi

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import tseslint from "typescript-eslint";
 import {defineConfig} from "eslint/config";
 
 export default defineConfig([
+    { ignores: ["dist"] },
     {
         files: ["{src,test}/**/*.{js,mjs,cjs,ts,mts,cts}"],
         plugins: {js},


### PR DESCRIPTION
Two gaps in this repo's CI, plus one lint papercut.

**Releases weren't reproducible.** npm served `@dodona/lit-state@1.2.0` as `latest`, but the git tags stopped at `v1.1.1`, so nothing in the repo recorded what actually shipped. That's what publishing by hand from a laptop gets you.

I've backfilled `v1.2.0` onto `9008ab6` (the PR #10 merge). That isn't a guess: a build of that commit is byte-identical to the published tarball's `dist/`, and its `package.json`, `README.md` and `LICENSE` match too, while the only other 1.2.0-versioned commit (`0418664`) builds to something different. The merge landed 07:58 UTC and 1.2.0 was published at 08:01 UTC. Every published version now has a tag.

So: a publish workflow modelled on the papyros one. Pushing a `v*` tag reruns the tests, verifies the tag is semver *and* matches `package.json`, publishes via npm trusted publishing (OIDC, with provenance), and opens a GitHub release with generated notes. That version check is exactly what would have caught the missing `v1.2.0`.

**Dependabot only watched npm**, so the pinned action versions in `test.yaml` and `lint.yaml` went stale with nobody noticing. Added the `github-actions` ecosystem, and brought the npm entry in line with papyros (Brussels-time monthly schedule, PR limit, `dependencies` label, eslint group). I dropped papyros's `@types*` and codemirror groups since neither matches anything here.

**And `yarn lint` fails after any build.** `dist/` is generated and gitignored, but eslint flat config doesn't read `.gitignore` and the `tseslint.configs.recommended` entry has no `files` filter, so it lints the emitted `.d.ts` files and trips over an `any` in `StateProperty.d.ts`. It only passes in CI because lint happens to run before anything is built. Added a global `ignores: ["dist"]`. Slightly off-topic for a release PR, but it bites the moment you build locally, which this PR makes people do more often.

**Manual testing instructions**
- All three YAML files parse: `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" <file>` for each.
- `yarn build && yarn lint` now passes with `dist/` on disk. Before this change it errors on `dist/StateProperty.d.ts`.
- `yarn typecheck` clean, `yarn test` 32/32.
- The publish workflow can't be dry-run without cutting a tag. First real exercise would be `v1.3.0`.

**Publishing is wired up.** The `npm` GitHub Actions environment now exists on this repo, and the trusted publisher for `@dodona/lit-state` is configured on npmjs.com against `dodona-edu/lit-state` and `.github/workflows/publish.yaml`. There is deliberately no `NODE_AUTH_TOKEN`: auth is OIDC only, which is why the setup-node step sets no `registry-url`.

None of that is exercised until the first `v*` tag is pushed, which would be `v1.3.0` off #12.

**Release note labels:** `release.yaml` categorises by the `feature`, `bug`, `chore` and `no-release-notes` labels, copied from papyros. Only `bug` existed here, so the other three are now created with the same colours and descriptions dodona uses. This PR is labelled `chore` and #12 `feature`, so the generated notes should sort themselves from the first release onwards.

**Checklist**
- Tests: n/a (CI config, no source change)
- Docs: n/a
- Announcement: n/a
- AI: Claude Code wrote this

Closes # n/a



