### PR TITLE
Run every workflow on node 24

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: yarn
       - name: Install dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: yarn
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: yarn
           # No registry-url: auth uses npm trusted publishing (OIDC), which
           # needs no .npmrc, and the registry defaults to registry.npmjs.org.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: yarn
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Let's use node 24 for every action, we're modern that way.

<details>

The publish workflow from #11 fails at the last step. Found it by actually cutting a release: `v1.3.0-rc.1` built and packed fine, then died on

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

The trusted publisher and the `npm` environment are both configured correctly. The problem is the npm version: OIDC trusted publishing needs npm 11.5.1 or newer, and the publish job ran **npm 10.9.8**, so npm never even attempted OIDC and fell straight back to looking for a token.

That's because the workflows pin node 22.x, which still ships npm 10. Papyros publishes on node 24.x (npm 11), which is why it works there. When #11 was written I matched lit-state's existing workflows for internal consistency, without spotting that the publish job is the one place where the npm floor actually matters.

So all four pins move to 24.x, not just publish: there's no reason for CI to run an older node than the one we publish from, and one version across the repo is one less thing to keep in sync.

**This is already proven to work.** I applied the publish half on the release branch and re-tagged, and it went green: `@dodona/lit-state@1.3.0-rc.1` is on npm under the `next` dist-tag, `latest` untouched at 1.2.0, and GitHub created the prerelease. This PR brings the fix back to `main` so the real `v1.3.0` doesn't hit the same wall.

</details>

**Manual testing instructions**
- Publish itself isn't dry-runnable without cutting a tag, which is exactly how the bug was found. Exercised end to end on `release/v1.3.0-rc.1`: run 31192179150 succeeded and npm shows `next` at 1.3.0-rc.1.
- Test and lint on node 24 locally (v24.18.0, npm 11.16.0): `yarn lint`, `yarn typecheck`, `yarn build` clean, `yarn test` 28/28. The CI runs on this PR cover it too.
- All three workflow files parse: `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1]))" <file>`.

**Checklist**
- Tests: n/a (CI config)
- Docs: n/a
- Announcement: n/a
- AI: Claude Code found and fixed this

Closes # n/a
